### PR TITLE
Name change, adding modules, updating tests etc

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/modules/custom/config_changes/config_changes.info.yml
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/config_changes/config_changes.info.yml
@@ -1,5 +1,6 @@
 name: 'config changes'
 description: 'Update configuration changes.'
+package: Red Hat Developers
 type: module
 core: 8.x
 dependencies:

--- a/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_common/rhd_common.info.yml
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_common/rhd_common.info.yml
@@ -1,4 +1,5 @@
-name: RDH Common
+name: RHD Common
 description: Define common functionality here.
 type: module
+package: Red Hat Developers
 core: 8.x

--- a/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_common/rhd_common.install
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_common/rhd_common.install
@@ -7,7 +7,7 @@
 /**
  * Implements hook_update_n().
  */
-function rdh_common_update_8004() {
+function rhd_common_update_8004() {
   // Ckeck if module exists.
   if(\Drupal::moduleHandler()->moduleExists('pathauto') == FALSE) {
     \Drupal::moduleHandler()->addModule('pathauto');

--- a/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_common/rhd_common.module
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_common/rhd_common.module
@@ -8,7 +8,7 @@
 /**
  * Implements hook_form_alter().
  */
-function rdh_common_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $form_state, $form_id) {
+function rhd_common_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $form_state, $form_id) {
   // If Article add form, add custom form validator.
   if ($form_id == 'node_article_edit_form' || $form_id == 'node_article_form') {
     // Override default validator with custom validator.
@@ -25,7 +25,7 @@ function rdh_common_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $for
 /**
  * Custom form validator.
  */
-function rdh_common_custom_form_validator(array &$element, \Drupal\Core\Form\FormStateInterface $form_state) {
+function rhd_common_custom_form_validator(array &$element, \Drupal\Core\Form\FormStateInterface $form_state) {
   // Trim the submitted value of whitespace and slashes.
   $alias = rtrim(trim($element['alias']['#value']), " \\/");
 

--- a/_docker/drupal/scripts/drupal_install_checker.rb
+++ b/_docker/drupal/scripts/drupal_install_checker.rb
@@ -71,7 +71,7 @@ class DrupalInstallChecker
       puts "Installing settings for module #{module_name}..."
       process_executor.exec!('/var/www/drupal/vendor/bin/drupal', ['--root=web','config:import:single',"#{module_name}.settings","/var/www/drupal/config/#{module_name}.settings"])
     end
-   end
+  end
 
   def install_theme
     puts 'Installing Drupal theme...'
@@ -84,7 +84,9 @@ class DrupalInstallChecker
                            'layoutmanager', 'hal', 'redhat_developers', 'syslog', 'diff', 'entity',
                            'entity_storage_migrate', 'key_value', 'multiversion', 'token', 'metatag',
                            'metatag_google_plus', 'metatag_open_graph', 'metatag_twitter_cards',
-                           'metatag_verification', 'admin_toolbar', 'admin_toolbar_tools','simple_sitemap']
+                           'metatag_verification', 'admin_toolbar', 'admin_toolbar_tools','simple_sitemap',
+                           'pathauto', 'config_update', 'ctools', 'rhd_common', 'config_changes'
+                          ]
 
     if @opts['environment'] == 'dev'
       module_install_args.push(*%w(devel kint))

--- a/_docker/tests/drupal/drupal_install_checker_test.rb
+++ b/_docker/tests/drupal/drupal_install_checker_test.rb
@@ -133,7 +133,10 @@ class DrupalInstallCheckerTest < Minitest::Test
                                                                              'metatag_open_graph',
                                                                              'metatag_twitter_cards',
                                                                              'metatag_verification', 'admin_toolbar',
-                                                                             'admin_toolbar_tools','simple_sitemap', 'devel', 'kint']]
+                                                                             'admin_toolbar_tools','simple_sitemap',
+                                                                             'pathauto', 'config_update', 'ctools',
+                                                                             'rhd_common', 'config_changes',
+                                                                             'devel', 'kint']]
 
 
     install_checker.install_modules
@@ -151,7 +154,10 @@ class DrupalInstallCheckerTest < Minitest::Test
                                                                             'metatag_open_graph',
                                                                             'metatag_twitter_cards',
                                                                             'metatag_verification', 'admin_toolbar',
-                                                                            'admin_toolbar_tools','simple_sitemap']]
+                                                                            'admin_toolbar_tools','simple_sitemap',
+                                                                            'pathauto', 'config_update', 'ctools',
+                                                                            'rhd_common', 'config_changes'
+                                                                             ]]
 
     @install_checker.install_modules
   end


### PR DESCRIPTION
* rdh_common -> rhd_common (I assume that was a naming slip)
* added the new custom modules to the "Red Hat Developers" package so
  you can find them easier
* adding the new modules on a clean install
* updating tests to reflect the new module additions